### PR TITLE
Add timeout to connect method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `php-sip2` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 2.0.1 - 2018-08-01
+
+### Added
+- SIP2Client::connect now accepts a timeout parameter, default 15 seconds
+
+
 ## 2.0.0 - 2018-07-29
 
 ### Added
@@ -21,7 +27,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Ensure client properly handles retries in event of CRC failure
 
 ### Removed
-- public methods and variables all removed - see [MIGRATION](MIGRATION.md)
+- original v1 classname changed
+- original public methods and variables all removed - see [MIGRATION](MIGRATION.md)
 
 ### Security
 - Nothing

--- a/src/SIP2Client.php
+++ b/src/SIP2Client.php
@@ -164,13 +164,13 @@ class SIP2Client implements LoggerAwareInterface
      *
      * @param string $address ip:port of remote SIP2 service
      * @param string|null $bind local ip to bind socket to
-     * @throws RuntimeException if connection cannot be established
+     * @param int $timeout number of seconds to allow for connection to succeed
      */
-    public function connect($address, $bind = null)
+    public function connect($address, $bind = null, $timeout = 15)
     {
         $this->logger->debug("SIP2Client: Attempting connection to $address");
 
-        $this->socket = $this->getSocketFactory()->createFromString($address, $scheme);
+        $this->socket = $this->getSocketFactory()->createClient($address, $timeout);
 
         try {
             if (!empty($bind)) {

--- a/tests/AbstractSIP2ClientTest.php
+++ b/tests/AbstractSIP2ClientTest.php
@@ -98,7 +98,7 @@ abstract class AbstractSIP2ClientTest extends \PHPUnit\Framework\TestCase
 
         //our factory just returns our mock
         $factory = $this->prophesize(\Socket\Raw\Factory::class);
-        $factory->createFromString(
+        $factory->createClient(
             Argument::type('string'),
             Argument::any()
         )->willReturn($socket->reveal());

--- a/tests/SIP2ClientTest.php
+++ b/tests/SIP2ClientTest.php
@@ -139,7 +139,7 @@ class SIP2ClientTest extends AbstractSIP2ClientTest
 
         //our factory will always fail to connect...
         $factory = $this->prophesize(\Socket\Raw\Factory::class);
-        $factory->createFromString(
+        $factory->createClient(
             Argument::type('string'),
             Argument::any()
         )->willReturn($socket->reveal());
@@ -161,7 +161,7 @@ class SIP2ClientTest extends AbstractSIP2ClientTest
 
         //our factory will always fail to connect...
         $factory = $this->prophesize(\Socket\Raw\Factory::class);
-        $factory->createFromString(
+        $factory->createClient(
             Argument::type('string'),
             Argument::any()
         )->willReturn($socket->reveal());


### PR DESCRIPTION
## Description

This adds an optional $timeout argument to the connect() method, defaulting to 15 seconds

## Motivation and context

In testing against real-world scenarios, connections hung for 120 seconds when unable to connect.

